### PR TITLE
Use timeago.js instead of javascript-time-ago

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "dependencies": {
     "highlight.js": "^11.4.0",
-    "javascript-time-ago": "^2.3.13",
     "jsonwebtoken": "^8.5.1",
     "marked": "^4.0.12",
     "next": "^12.1.0",
     "postcss-hover-media-feature": "^1.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "sass": "^1.49.7"
+    "sass": "^1.49.7",
+    "timeago.js": "^4.0.2"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.8",

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -1,14 +1,10 @@
-import TimeAgo from 'javascript-time-ago';
-import en from 'javascript-time-ago/locale/en.json';
 import styles from '../styles/Home.module.scss';
 import Layout from '../components/Layout';
 import Image from 'next/image';
 import { marked } from 'marked';
 import hljs from 'highlight.js';
 import { fetchGitHub, readAccessToken } from '../lib/github';
-
-TimeAgo.addDefaultLocale(en);
-const timeAgo = new TimeAgo('en-US');
+import timeago from 'timeago.js';
 
 export async function getStaticPaths() {
   console.log('[Next.js] Running getStaticPaths for issue page');
@@ -74,8 +70,8 @@ export default function Issue({ issue, comments }: any) {
       <div className={styles.comments}>
         <a
           href={issue.html_url}
-          target="_blank"
-          rel="noreferrer"
+          target='_blank'
+          rel='noreferrer'
           className={styles.comment}
           key={issue.id}
         >
@@ -84,7 +80,7 @@ export default function Issue({ issue, comments }: any) {
               src={issue.user?.avatar_url || '/avatar.png'}
               alt={issue.user.login}
               className={styles.rounded}
-              objectFit="cover"
+              objectFit='cover'
               height={32}
               width={32}
             />
@@ -92,7 +88,7 @@ export default function Issue({ issue, comments }: any) {
           <div className={styles.comment_div}>
             <div className={styles.comment_timestamp}>
               <b>{issue.user.login}</b> commented{' '}
-              {timeAgo.format(new Date(issue.created_at))}
+              {timeago.format(issue.created_at)}
             </div>
             <div
               dangerouslySetInnerHTML={{
@@ -107,8 +103,8 @@ export default function Issue({ issue, comments }: any) {
         {comments.map((comment: any) => (
           <a
             href={comment.html_url}
-            target="_blank"
-            rel="noreferrer"
+            target='_blank'
+            rel='noreferrer'
             className={styles.comment}
             key={comment.id}
           >
@@ -117,7 +113,7 @@ export default function Issue({ issue, comments }: any) {
                 src={comment.user?.avatar_url || '/avatar.png'}
                 alt={comment.user.login}
                 className={styles.rounded}
-                objectFit="cover"
+                objectFit='cover'
                 height={32}
                 width={32}
               />
@@ -125,7 +121,7 @@ export default function Issue({ issue, comments }: any) {
             <div className={styles.comment_div}>
               <div className={styles.comment_timestamp}>
                 <b>{comment.user.login}</b> commented{' '}
-                {timeAgo.format(new Date(comment.created_at))}
+                {timeago.format(comment.created_at)}
               </div>
               <div
                 dangerouslySetInnerHTML={{

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,9 @@
-import TimeAgo from 'javascript-time-ago';
-import en from 'javascript-time-ago/locale/en.json';
 import styles from '../styles/Home.module.scss';
 import Link from 'next/link';
 import Layout from '../components/Layout';
 import { CommentIcon, IssueIcon } from '../components/icons';
 import { fetchGitHub, readAccessToken } from '../lib/github';
-
-TimeAgo.addDefaultLocale(en);
-const timeAgo = new TimeAgo('en-US');
+import timeago from 'timeago.js';
 
 export async function getStaticProps() {
   const accessToken = await readAccessToken();
@@ -50,8 +46,7 @@ export default function Home({ issues, stargazers_count, forks_count }: any) {
               <div>
                 <div className={styles.issue_title}>{issue.title}</div>
                 <div className={styles.issue_desc}>
-                  #{issue.number} opened{' '}
-                  {timeAgo.format(new Date(issue.created_at))} by{' '}
+                  #{issue.number} opened {timeago.format(issue.created_at)} by{' '}
                   {issue.user.login}
                 </div>
               </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,13 +1101,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-javascript-time-ago@^2.3.13:
-  version "2.3.13"
-  resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.3.13.tgz#ccea41f5c07d26483e1b707c28b1ec71442ccdca"
-  integrity sha512-LiNqRLERXpePGLejdqjbxfMkFlwx+2RDz21Jfw/3l2mH20fTa6nAtwOFQmAK5l0SfaV7HvixJgTCxyph9VmG1Q==
-  dependencies:
-    relative-time-format "^1.0.7"
-
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1578,11 +1571,6 @@ regexpp@^3.2.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
-relative-time-format@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/relative-time-format/-/relative-time-format-1.0.7.tgz#c88423fa3fd7ee6d0d87e4e74a9260b4f367f201"
-  integrity sha512-BoLPaoL5y94ngPI4iJ9mNHqRS8NA+Hjs6oYHL5UYkbnA7/iTlvJiMoQQt8txhHhc+Y3e6yXWhwTAKvsQhnx2yg==
-
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -1762,6 +1750,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+timeago.js@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/timeago.js/-/timeago.js-4.0.2.tgz#724e8c8833e3490676c7bb0a75f5daf20e558028"
+  integrity sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Won't make a huge difference but `timeago` has less size

## `javascript-time-ago`
![image](https://user-images.githubusercontent.com/51731966/161413473-07567a41-6a21-43f7-b4eb-f99522af5c32.png)


## `timeago.js`
![image](https://user-images.githubusercontent.com/51731966/161413460-5ec06875-fcd2-4828-b178-cbe6565ff726.png)
