### PR TITLE
Prevent layout shift when scrollbars appear on OSs with non-floating scrollbars

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,7 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   color: #8b949e;
   background: #0d1117;
+  scrollbar-gutter: stable;
 }
 
 a {


### PR DESCRIPTION
Love this demo @leerob  :)

I noticed some layout shifting when the scrollbars appeared on the homepage but disappeared on the short bug ticket pages. [`scrollbar-gutter'](https://defensivecss.dev/tip/scrollbar-gutter/) should sort this out!

This won't happen on an OS with 'floating' or disappearing scrollbars like macOS or iOS, but it will happen on Windows (or for Mac devs like me who have this setting turned on to catch this sort of thing: 

![screenshot of macOS scrollbar behaviour settings with the 'Always' radio button selected](https://github.com/leerob/on-demand-isr/assets/6339853/26d08718-d22c-48bc-889f-49b729386993)
